### PR TITLE
Change pip to conda dependency

### DIFF
--- a/software/environment.yml
+++ b/software/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - altair
   - vl-convert-python
   - jupyterlab
+  - jupyterlab_code_formatter
   - pytest
   - scalene
   - flit
@@ -25,5 +26,3 @@ dependencies:
   - black
   - isort
   - pip
-  - pip:
-    - jupyterlab-code-formatter

--- a/software/environment.yml
+++ b/software/environment.yml
@@ -25,4 +25,3 @@ dependencies:
   - sphinx-autobuild
   - black
   - isort
-  - pip


### PR DESCRIPTION
Avoids error when installing from remote location. `conda create -f https://raw.github....`